### PR TITLE
Migrate package configuration for Julia 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # ctags
 tags
+
+# Pkg
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,10 @@
+name = "Avro"
+uuid = "cb912096-b518-5389-8790-85f0e02849dc"
+author = ["Gio Borje"]
+version = "0.0.4"
+
+[deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Libz = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
+Snappy = "59d4ed8c-697a-5b28-a4c7-fe95c22820f9"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-JSON
-Libz
-Snappy


### PR DESCRIPTION
**Purpose.** To publish new versions of this library through the package registry, the project must be updated to use the new package management system introduced in [the release of Julia 1.0][2].

**Approach.** Unfortunately, there was no clear migration guide for Julia 0.6 packages. To migrate the package configuration, we adapted from the guide to
create packages as outlined in [Pkg][1].

**Changes.** To reconfigure this project, we

1. created a file 'Project.toml' with known metadata;
3. found the existing package UUID from the General registry;
4. launched a REPL;
5. activated the package environment;
6. added dependencies from 'REQUIRE' for the project;
7. added dependency to the package 'Test' to run tests;
8. tested the package, which passes;

Additional changes include:

- updating the version to '0.0.4' from '0.0.3';
- removing the deprecated file 'REQUIRE' for dependencies;
- adding the generated file 'Manfest.toml'.

[1]: https://julialang.github.io/Pkg.jl/v1/creating-packages/6365be9
[2]: https://julialang.org/blog/2018/08/one-point-zero
