### PR TITLE
Implement the rest of the Iterator interface

### DIFF
--- a/src/data_file_reader.jl
+++ b/src/data_file_reader.jl
@@ -66,6 +66,12 @@ function Base.iterate(file_reader::Reader, state)
 end
 Base.iterate(file_reader::Reader) = iterate(file_reader, start(file_reader))
 
+Base.IteratorSize(::Type{Reader}) = Base.SizeUnknown()
+
+Base.IteratorEltype(::Type{Reader}) = Base.HasEltype()
+
+Base.eltype(::Type{Reader}) = GenericRecord
+
 """
 Read the header directly the input decoder.
 """

--- a/src/io.jl
+++ b/src/io.jl
@@ -28,7 +28,13 @@ export Encoder,
        decode_byte,
        decode_bytes,
        decode_fixed,
-       decode_string
+       decode_string,
+       InvalidVariableLengthEncoding
+
+
+struct InvalidVariableLengthEncoding <: Exception end
+
+Base.showerror(io, err::InvalidVariableLengthEncoding) = print(io, "Invalid variable-length integer encoding")
 
 abstract type Encoder end;
 abstract type Decoder end;
@@ -89,7 +95,7 @@ function _encode_varint(stream::IO, n::T) where T <: Integer
         n >>>= 7
     end
     if n > 0x7f
-        throw(Exception("Invalid variable-length integer encoding"))
+        throw(InvalidVariableLengthEncoding())
     end
     bytes_written += write(stream, n % UInt8)
 end
@@ -132,7 +138,7 @@ function _decode_varint(stream::IO, ::Type{T}) where T <: Integer
         bytes_read += 1
     end
     if b > 0x7f
-        throw(Exception("Invalid variable-length integer encoding"))
+        throw(InvalidVariableLengthEncoding())
     end
     n
 end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -71,6 +71,13 @@ struct SchemaParseException <: Exception
     message::String
 end
 
+struct InvalidPrimitiveSchemaName <: Exception end
+Base.showerror(io, err::InvalidPrimitiveSchemaName) = print(io, "Invalid schema typename")
+
+struct InvalidSchemaOrder <: Exception
+    name::String
+end
+Base.showerror(io, err::InvalidSchemaOrder) = print(io, "Invalid order name: $(err.name)")
 """
 The parent of the Avro Schema hierarchy.
 """
@@ -106,7 +113,7 @@ function PrimitiveSchema(typename::String)
     elseif typename == "double"
         return DOUBLE
     else
-        throw(Exception("Invalid schema typename"))
+        throw(InvalidPrimitiveSchemaName())
     end
 end
 
@@ -211,7 +218,7 @@ function Order(name::String)
     elseif clean_name == "IGNORE"
         Ignore
     else
-        throw(Exception("Invalid order name: $name"))
+        throw(InvalidSchemaOrder(name))
     end
 end
 

--- a/test/data_file.jl
+++ b/test/data_file.jl
@@ -44,10 +44,20 @@ records = [
 
     read_buffer = IOBuffer(contents)
     read_records = GenericRecord[]
-    for record in DataFile.Readers.wrap(read_buffer)
+    record_iterator = DataFile.Readers.wrap(read_buffer)
+
+    @test Base.IteratorEltype(record_iterator) == Base.HasEltype()
+    @test eltype(record_iterator) == GenericRecord
+    @test Base.IteratorSize(record_iterator) == Base.SizeUnknown()
+    for record in record_iterator
         push!(read_records, record)
     end
     @test records == read_records
+
+    read_buffer = IOBuffer(contents)
+    record_iterator = DataFile.Readers.wrap(read_buffer)
+    stateful_iterator = Base.Iterators.Stateful(record_iterator)
+    @test popfirst!(stateful_iterator) == records[1]
 end
 
 end


### PR DESCRIPTION
In particular, implementing `Base.IteratorSize` allows using methods from `Base.Iterators`.