### PR TITLE
Implement the rest of the Iterator interface

### DIFF
--- a/src/data_file_reader.jl
+++ b/src/data_file_reader.jl
@@ -66,6 +66,12 @@ function Base.iterate(file_reader::Reader, state)
 end
 Base.iterate(file_reader::Reader) = iterate(file_reader, start(file_reader))
 
+Base.IteratorSize(::Type{Reader}) = Base.SizeUnknown()
+
+Base.IteratorEltype(::Type{Reader}) = Base.HasEltype()
+
+Base.eltype(::Type{Reader}) = GenericRecord
+
 """
 Read the header directly the input decoder.
 """

--- a/test/data_file.jl
+++ b/test/data_file.jl
@@ -44,10 +44,20 @@ records = [
 
     read_buffer = IOBuffer(contents)
     read_records = GenericRecord[]
-    for record in DataFile.Readers.wrap(read_buffer)
+    record_iterator = DataFile.Readers.wrap(read_buffer)
+
+    @test Base.IteratorEltype(record_iterator) == Base.HasEltype()
+    @test eltype(record_iterator) == GenericRecord
+    @test Base.IteratorSize(record_iterator) == Base.SizeUnknown()
+    for record in record_iterator
         push!(read_records, record)
     end
     @test records == read_records
+
+    read_buffer = IOBuffer(contents)
+    record_iterator = DataFile.Readers.wrap(read_buffer)
+    stateful_iterator = Base.Iterators.Stateful(record_iterator)
+    @test popfirst!(stateful_iterator) == records[1]
 end
 
 end


### PR DESCRIPTION
In particular, implementing `Base.IteratorSize` allows using methods
from `Base.Iterators`.